### PR TITLE
FireRainbow is marked as incompatible with Firefox 4 RC

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -10,7 +10,7 @@
             <Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>2.0</em:minVersion>
-                <em:maxVersion>4.0b8pre</em:maxVersion>
+                <em:maxVersion>4.0.*</em:maxVersion>
             </Description>
         </em:targetApplication>
         <!-- Firebug extension -->


### PR DESCRIPTION
This change updates the addon manifest to set the maxVersion to 4.0.\* so FFX stops complaining about incompatibilities.
